### PR TITLE
feat: auto-enable strategies after login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A Windows console app that automates NinjaTrader 8 login and strategy enabling using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches or attaches to NinjaTrader, fills in credentials, clicks login, selects live or simulation mode, then finds the Control Center and enables all strategies.
+A Windows console app that automates NinjaTrader 8 login and strategy enabling using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches NinjaTrader (aborts if already running), fills in credentials, clicks login, selects live or simulation mode, then finds the Control Center and enables all strategies.
 
 ## Build & Run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A Windows console app that automates NinjaTrader 8 login using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches or attaches to NinjaTrader, fills in credentials, clicks login, then selects live or simulation mode.
+A Windows console app that automates NinjaTrader 8 login and strategy enabling using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches or attaches to NinjaTrader, fills in credentials, clicks login, selects live or simulation mode, then finds the Control Center and enables all strategies.
 
 ## Build & Run
 
@@ -23,10 +23,11 @@ All configuration via environment variables (or path as first CLI arg):
 - `NT8A_PASS` - NT password
 - `NT8A_PATH` - (optional) path to NinjaTrader.exe. Defaults to `C:\Program Files\NinjaTrader 8\bin\NinjaTrader.exe`.
 - `NT8A_LIVE` - (optional) `TRUE` for live trading, `FALSE` for sim. Omit for multi-provider mode where no mode selector appears.
+- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `30`.
 
 ## Key Dependency
 
-**FlaUI.UIA3 v4.0.0** - UI Automation library. Elements are located by AutomationId (e.g., `tbUserName`, `passwordBox`, `btnLogin`, `btnLiveTrading`, `btnSimulation`). Uses `Retry.WhileNull()` for waiting on post-login dialogs.
+**FlaUI.UIA3 v5.0.0** - UI Automation library. Elements are located by AutomationId (e.g., `tbUserName`, `passwordBox`, `btnLogin`, `btnLiveTrading`, `btnSimulation`). Uses `Retry.WhileNull()` for waiting on post-login dialogs.
 
 ## License
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ All configuration via environment variables (or path as first CLI arg):
 - `NT8A_PASS` - NT password
 - `NT8A_PATH` - (optional) path to NinjaTrader.exe. Defaults to `C:\Program Files\NinjaTrader 8\bin\NinjaTrader.exe`.
 - `NT8A_LIVE` - (optional) `TRUE` for live trading, `FALSE` for sim. Omit for multi-provider mode where no mode selector appears.
-- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `30`.
+- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `10`.
 
 ## Key Dependency
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
 <!--
-SPDX-FileCopyrightText: � 2024 Trey Thomas <trey@treythomas.codes>
-	
+SPDX-FileCopyrightText: © 2024 Trey Thomas <trey@treythomas.codes>
+
 SPDX-License-Identifier: MPL-2.0
 -->
 
-# nt8-autologin
-Quick and dirty app to automatically launch and log into NinjaTrader 8.
+# NT8Automater
+Automatically launches NinjaTrader 8, logs in, and enables all strategies in the Control Center.
 
 > **Use at your own risk.** This software is provided as-is with no warranties. You are a chode if you run software like this from the internet without auditing it and understanding it. It interacts with your trading software, and you are solely responsible for any consequences of its use.
 
+## What It Does
+
+1. Launches NinjaTrader 8 (aborts if already running)
+2. Fills in credentials and clicks Login
+3. Selects Live or Simulation mode (if configured)
+4. Waits for the Control Center to appear
+5. Waits for connections to initialize
+6. Navigates to the Strategies tab and enables all strategies
+
 ## Environment Vars
 
-* NT8A_USER - NT username
-* NT8A_PASS - NT password
-* NT8A_PATH - (optional) path to NinjaTrader.exe. Defaults to `C:\Program Files\NinjaTrader 8\bin\NinjaTrader.exe`.
-* NT8A_LIVE - (optional) TRUE for live trading, FALSE for sim. Omit for multi-provider mode (no mode selector).
+* `NT8A_USER` - NT username
+* `NT8A_PASS` - NT password
+* `NT8A_PATH` - (optional) path to NinjaTrader.exe. Defaults to `C:\Program Files\NinjaTrader 8\bin\NinjaTrader.exe`.
+* `NT8A_LIVE` - (optional) `TRUE` for live trading, `FALSE` for sim. Omit for multi-provider mode (no mode selector).
+* `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `10`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 -->
 
 # NT8Automater
+
 Automatically launches NinjaTrader 8, logs in, and enables all strategies in the Control Center.
 
 > **Use at your own risk.** This software is provided as-is with no warranties. You are a chode if you run software like this from the internet without auditing it and understanding it. It interacts with your trading software, and you are solely responsible for any consequences of its use.

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -14,8 +14,15 @@ string path = Environment.GetEnvironmentVariable("NT8A_PATH")
 if (args.Length > 0)
     path = args[0];
 
+var processName = Path.GetFileNameWithoutExtension(path);
+if (System.Diagnostics.Process.GetProcessesByName(processName).Length > 0)
+{
+    Console.WriteLine($"Aborting: {processName} is already running.");
+    return;
+}
+
 using var automation = new UIA3Automation();
-using var app = Application.AttachOrLaunch(new System.Diagnostics.ProcessStartInfo(path));
+using var app = Application.Launch(new System.Diagnostics.ProcessStartInfo(path));
 
 var window = app.GetMainWindow(automation)
     ?? throw new InvalidOperationException("Could not find NinjaTrader main window.");

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -44,8 +44,8 @@ btnLogin.Invoke();
 var live = Environment.GetEnvironmentVariable("NT8A_LIVE");
 if (!string.IsNullOrEmpty(live))
 {
-    var btnLive = Retry.WhileNull(() => window.FindFirstDescendant(cf => cf.ByAutomationId("btnLiveTrading")).AsButton(), TimeSpan.FromSeconds(10));
-    var btnSim = Retry.WhileNull(() => window.FindFirstDescendant(cf => cf.ByAutomationId("btnSimulation")).AsButton(), TimeSpan.FromSeconds(10));
+    var btnLive = Retry.WhileNull(() => window.FindFirstDescendant(cf => cf.ByAutomationId("btnLiveTrading"))?.AsButton(), TimeSpan.FromSeconds(10));
+    var btnSim = Retry.WhileNull(() => window.FindFirstDescendant(cf => cf.ByAutomationId("btnSimulation"))?.AsButton(), TimeSpan.FromSeconds(10));
 
     if (bool.Parse(live)) btnLive.Result!.Invoke(); else btnSim.Result!.Invoke();
 }
@@ -63,7 +63,15 @@ var ccWindow = controlCenter.Result
 Console.WriteLine($"Found Control Center: \"{ccWindow.Name}\"");
 
 // --- Phase 2: Wait for connection readiness ---
-var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 10;
+var delayRaw = Environment.GetEnvironmentVariable("NT8A_CONN_DELAY");
+var delaySec = 10;
+if (!string.IsNullOrWhiteSpace(delayRaw))
+{
+    if (int.TryParse(delayRaw, out var parsed) && parsed >= 0 && parsed <= 3600)
+        delaySec = parsed;
+    else
+        Console.WriteLine("WARNING: NT8A_CONN_DELAY must be an integer between 0 and 3600. Using default 10s.");
+}
 Console.WriteLine($"Waiting {delaySec}s for connections and charts to initialize...");
 Thread.Sleep(TimeSpan.FromSeconds(delaySec));
 Console.WriteLine("Connection delay complete.");
@@ -123,6 +131,10 @@ foreach (var row in rows)
     else
     {
         cb.Click();
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (cb.IsChecked != true && DateTime.UtcNow < deadline)
+            Thread.Sleep(100);
+
         if (cb.IsChecked == true)
         {
             enabled++;

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -64,3 +64,63 @@ Console.WriteLine($"Waiting {delaySec}s for connections and charts to initialize
 Thread.Sleep(TimeSpan.FromSeconds(delaySec));
 Console.WriteLine("Connection delay complete.");
 
+// --- Phase 3: Navigate to Strategies tab and enable all strategies ---
+Console.WriteLine("Looking for Strategies tab...");
+var strategiesTab = Retry.WhileNull(
+    () => ccWindow.FindFirstDescendant(cf => cf.ByName("Strategies"))
+        ?? ccWindow.FindFirstDescendant(cf => cf.ByAutomationId("Strategies")),
+    TimeSpan.FromSeconds(30),
+    TimeSpan.FromSeconds(2)
+);
+var tabElement = strategiesTab.Result
+    ?? throw new InvalidOperationException("Could not find Strategies tab in Control Center.");
+
+// Click the Strategies tab to make sure it's selected
+tabElement.Click();
+Console.WriteLine("Strategies tab selected.");
+Thread.Sleep(TimeSpan.FromSeconds(2)); // Brief pause for tab content to render
+
+// Find the strategies data grid
+var grid = Retry.WhileNull(
+    () => ccWindow.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.DataGrid))
+        ?? ccWindow.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.Table)),
+    TimeSpan.FromSeconds(15),
+    TimeSpan.FromSeconds(2)
+);
+var strategiesGrid = grid.Result
+    ?? throw new InvalidOperationException("Could not find strategies grid.");
+
+// Find all rows and enable each strategy
+var rows = strategiesGrid.FindAllDescendants(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.DataItem));
+if (rows.Length == 0)
+    rows = strategiesGrid.FindAllDescendants(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.Custom));
+
+Console.WriteLine($"Found {rows.Length} strategy row(s).");
+
+var enabled = 0;
+foreach (var row in rows)
+{
+    // Find the Enabled checkbox within this row
+    var checkbox = row.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.CheckBox));
+    if (checkbox is null)
+    {
+        Console.WriteLine($"  Row: no checkbox found, skipping.");
+        continue;
+    }
+
+    var cb = checkbox.AsCheckBox();
+    var strategyName = row.Name ?? "unknown";
+    if (cb.IsChecked == true)
+    {
+        Console.WriteLine($"  {strategyName}: already enabled.");
+    }
+    else
+    {
+        cb.IsChecked = true;
+        enabled++;
+        Console.WriteLine($"  {strategyName}: enabled.");
+    }
+}
+
+Console.WriteLine($"Done. Enabled {enabled} strategy/strategies. {rows.Length - enabled} were already enabled or skipped.");
+

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -47,7 +47,10 @@ if (!string.IsNullOrEmpty(live))
     var btnLive = Retry.WhileNull(() => window.FindFirstDescendant(cf => cf.ByAutomationId("btnLiveTrading"))?.AsButton(), TimeSpan.FromSeconds(10));
     var btnSim = Retry.WhileNull(() => window.FindFirstDescendant(cf => cf.ByAutomationId("btnSimulation"))?.AsButton(), TimeSpan.FromSeconds(10));
 
-    if (bool.Parse(live)) btnLive.Result!.Invoke(); else btnSim.Result!.Invoke();
+    var targetBtn = bool.Parse(live) ? btnLive.Result : btnSim.Result;
+    if (targetBtn is null)
+        throw new InvalidOperationException("Could not find Live/Simulation mode button.");
+    targetBtn.Invoke();
 }
 
 // --- Phase 1: Find the Control Center ---

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -122,7 +122,7 @@ foreach (var row in rows)
     }
     else
     {
-        cb.IsChecked = true;
+        cb.Click();
         if (cb.IsChecked == true)
         {
             enabled++;

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -49,7 +49,7 @@ var controlCenter = Retry.WhileNull(
     () =>
     {
         var windows = app.GetAllTopLevelWindows(automation);
-        return windows.FirstOrDefault(w => w.Title.Contains("Control Center"));
+        return windows.FirstOrDefault(w => w.Title?.Contains("Control Center") == true);
     },
     TimeSpan.FromSeconds(120),
     TimeSpan.FromSeconds(2)
@@ -81,6 +81,8 @@ Console.WriteLine("Strategies tab selected.");
 Thread.Sleep(TimeSpan.FromSeconds(2)); // Brief pause for tab content to render
 
 // Find the strategies data grid
+// Assumes the Strategies tab grid is the first DataGrid/Table descendant in the Control Center.
+// If this finds the wrong grid, scope the search using a more specific AutomationId discovered via FlaUI Inspect.
 var grid = Retry.WhileNull(
     () => ccWindow.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.DataGrid))
         ?? ccWindow.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.Table)),
@@ -116,7 +118,9 @@ foreach (var row in rows)
     }
     else
     {
-        cb.IsChecked = true;
+        cb.Click();
+        if (cb.IsChecked != true)
+            Console.WriteLine($"  WARNING: {strategyName} checkbox did not toggle to enabled.");
         enabled++;
         Console.WriteLine($"  {strategyName}: enabled.");
     }

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -115,11 +115,16 @@ foreach (var row in rows)
     }
     else
     {
-        cb.Click();
-        if (cb.IsChecked != true)
+        cb.IsChecked = true;
+        if (cb.IsChecked == true)
+        {
+            enabled++;
+            Console.WriteLine($"  {strategyName}: enabled.");
+        }
+        else
+        {
             Console.WriteLine($"  WARNING: {strategyName} checkbox did not toggle to enabled.");
-        enabled++;
-        Console.WriteLine($"  {strategyName}: enabled.");
+        }
     }
 }
 

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -58,3 +58,9 @@ var ccWindow = controlCenter.Result
     ?? throw new InvalidOperationException("Control Center window did not appear within timeout.");
 Console.WriteLine($"Found Control Center: \"{ccWindow.Title}\"");
 
+// --- Phase 2: Wait for connection readiness ---
+var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 30;
+Console.WriteLine($"Waiting {delaySec}s for connections and charts to initialize...");
+Thread.Sleep(TimeSpan.FromSeconds(delaySec));
+Console.WriteLine("Connection delay complete.");
+

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -52,7 +52,8 @@ var controlCenter = Retry.WhileNull(
         return windows.FirstOrDefault(w => w.Title?.Contains("Control Center") == true);
     },
     TimeSpan.FromSeconds(120),
-    TimeSpan.FromSeconds(2)
+    TimeSpan.FromSeconds(2),
+    ignoreException: true
 );
 var ccWindow = controlCenter.Result
     ?? throw new InvalidOperationException("Control Center window did not appear within timeout.");

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -43,21 +43,17 @@ if (!string.IsNullOrEmpty(live))
     if (bool.Parse(live)) btnLive.Result!.Invoke(); else btnSim.Result!.Invoke();
 }
 
-// --- Phase 1: Find the Control Center window ---
-Console.WriteLine("Waiting for Control Center window...");
+// --- Phase 1: Find the Control Center ---
+Console.WriteLine("Waiting for Control Center...");
 var controlCenter = Retry.WhileNull(
-    () =>
-    {
-        var windows = app.GetAllTopLevelWindows(automation);
-        return windows.FirstOrDefault(w => w.Title?.Contains("Control Center") == true);
-    },
+    () => automation.GetDesktop().FindFirstDescendant(cf => cf.ByAutomationId("ControlCenter")),
     TimeSpan.FromSeconds(120),
     TimeSpan.FromSeconds(2),
     ignoreException: true
 );
 var ccWindow = controlCenter.Result
-    ?? throw new InvalidOperationException("Control Center window did not appear within timeout.");
-Console.WriteLine($"Found Control Center: \"{ccWindow.Title}\"");
+    ?? throw new InvalidOperationException("Control Center did not appear within timeout.");
+Console.WriteLine($"Found Control Center: \"{ccWindow.Name}\"");
 
 // --- Phase 2: Wait for connection readiness ---
 var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 30;

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -56,7 +56,7 @@ var ccWindow = controlCenter.Result
 Console.WriteLine($"Found Control Center: \"{ccWindow.Name}\"");
 
 // --- Phase 2: Wait for connection readiness ---
-var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 30;
+var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 10;
 Console.WriteLine($"Waiting {delaySec}s for connections and charts to initialize...");
 Thread.Sleep(TimeSpan.FromSeconds(delaySec));
 Console.WriteLine("Connection delay complete.");

--- a/TreyThomasCodes.Nt8Automater/Program.cs
+++ b/TreyThomasCodes.Nt8Automater/Program.cs
@@ -43,3 +43,18 @@ if (!string.IsNullOrEmpty(live))
     if (bool.Parse(live)) btnLive.Result!.Invoke(); else btnSim.Result!.Invoke();
 }
 
+// --- Phase 1: Find the Control Center window ---
+Console.WriteLine("Waiting for Control Center window...");
+var controlCenter = Retry.WhileNull(
+    () =>
+    {
+        var windows = app.GetAllTopLevelWindows(automation);
+        return windows.FirstOrDefault(w => w.Title.Contains("Control Center"));
+    },
+    TimeSpan.FromSeconds(120),
+    TimeSpan.FromSeconds(2)
+);
+var ccWindow = controlCenter.Result
+    ?? throw new InvalidOperationException("Control Center window did not appear within timeout.");
+Console.WriteLine($"Found Control Center: \"{ccWindow.Title}\"");
+

--- a/docs/plans/2026-03-04-nt8-strategy-autostart-design.md
+++ b/docs/plans/2026-03-04-nt8-strategy-autostart-design.md
@@ -25,7 +25,7 @@ Extend the existing C#/.NET UIA3 application that already launches NT8 and handl
 
 ### Flow
 
-```
+```text
 [Launch NT8] -> [Login on Splash Screen] -> [Find Control Center] -> [Verify Connection] -> [Enable Strategies]
      |                  |                          |                        |                       |
   (existing)        (existing)                 (new step)              (new step)              (new step)

--- a/docs/plans/2026-03-04-nt8-strategy-autostart-design.md
+++ b/docs/plans/2026-03-04-nt8-strategy-autostart-design.md
@@ -40,17 +40,13 @@ After login completes on the NT8 splash screen, the splash closes and the Contro
 - Timeout after configurable duration (e.g., 60 seconds)
 - Store window reference for subsequent phases
 
-### Phase 2: Verify Data Connection
+### Phase 2: Wait for Connection Readiness
 
-Before enabling strategies, confirm the data/broker connection is fully established.
+Before enabling strategies, wait for the data/broker connection to establish and charts to initialize.
 
-- Locate the connection status indicator in the Control Center
-- Poll until the single data connection shows "Connected" status
-- After connected status confirmed, wait an additional configurable buffer (default: 15-30 seconds) for:
-  - Historical data downloads to complete
-  - Charts to fully render
-  - Any startup initialization to finish
-- Timeout if connection doesn't establish within configurable duration (e.g., 5 minutes)
+**Current implementation:** A fixed delay controlled by the `NT8A_CONN_DELAY` environment variable (default: 10 seconds). This provides a simple, reliable baseline without requiring knowledge of internal UI element IDs.
+
+**Future enhancement:** Poll the connection status indicator in the Control Center until the data connection shows "Connected" status, then wait an additional configurable buffer (15-30 seconds) for historical data downloads and chart rendering. Timeout if connection doesn't establish within a configurable duration (e.g., 5 minutes). This requires discovering the connection status element's AutomationId via FlaUI Inspect.
 
 ### Phase 3: Enable Strategies
 

--- a/docs/plans/2026-03-04-nt8-strategy-autostart-design.md
+++ b/docs/plans/2026-03-04-nt8-strategy-autostart-design.md
@@ -1,0 +1,94 @@
+# NinjaTrader 8 Strategy Auto-Start Design
+
+## Problem
+
+NinjaTrader 8 does not support auto-starting strategies after the application launches. Strategies must be manually enabled by checking the "Enabled" checkbox. For an unattended server running 3-5 fixed strategies on charts, this requires human intervention after every restart.
+
+## Approach: External UI Automation (UIA3)
+
+Extend the existing C#/.NET UIA3 application that already launches NT8 and handles login. Add a new phase that finds the Control Center, verifies the data connection, and enables strategies via the Strategies tab.
+
+### Why This Approach
+
+- Builds on existing UIA3 infrastructure (launch + login already implemented)
+- Does not touch NT8 internals (no reflection, no unsupported NinjaScript APIs)
+- Strategies remain unmodified - no NinjaScript changes needed
+- If NT8 UI changes on update, only the automation selectors need updating, not trading code
+- External watchdog process is an advantage for an unattended server
+
+### Alternatives Considered
+
+1. **NT8 Addon with Reflection** - Extremely fragile, relies on private internals that change between versions, complex reverse-engineering required. Rejected due to maintenance burden.
+2. **NT8 Addon with WPF Visual Tree Walking** - Less fragile than reflection but still unsupported, requires addon development experience, threading complexity. Rejected in favor of extending existing external automation.
+
+## Architecture
+
+### Flow
+
+```
+[Launch NT8] -> [Login on Splash Screen] -> [Find Control Center] -> [Verify Connection] -> [Enable Strategies]
+     |                  |                          |                        |                       |
+  (existing)        (existing)                 (new step)              (new step)              (new step)
+```
+
+### Phase 1: Find Control Center Window
+
+After login completes on the NT8 splash screen, the splash closes and the Control Center window appears.
+
+- Poll for the Control Center window by title (e.g., "Control Center") or class name
+- Use `AutomationElement.RootElement` search or FlaUI equivalent
+- Timeout after configurable duration (e.g., 60 seconds)
+- Store window reference for subsequent phases
+
+### Phase 2: Verify Data Connection
+
+Before enabling strategies, confirm the data/broker connection is fully established.
+
+- Locate the connection status indicator in the Control Center
+- Poll until the single data connection shows "Connected" status
+- After connected status confirmed, wait an additional configurable buffer (default: 15-30 seconds) for:
+  - Historical data downloads to complete
+  - Charts to fully render
+  - Any startup initialization to finish
+- Timeout if connection doesn't establish within configurable duration (e.g., 5 minutes)
+
+### Phase 3: Enable Strategies
+
+Once connections are verified:
+
+1. Click the "Strategies" tab in the Control Center
+2. Locate strategy rows in the strategies grid
+3. For each strategy: find the Enabled checkbox and check it if unchecked
+4. Verify each strategy shows as Enabled after clicking
+5. Log success/failure for each strategy
+
+**Strategy identification:** Enable all strategies in the grid. The workspace is pre-configured with only the target strategies, so enable-all is safe and simple.
+
+### Error Handling & Resilience
+
+For unattended server operation:
+
+- **Retry logic:** If a strategy fails to enable, retry up to N times with a delay between attempts
+- **Timeouts:** Configurable timeouts at each phase (Control Center discovery, connection, strategy enabling)
+- **Logging:** Log every step with timestamps for remote diagnosis
+- **Failure alerting:** On timeout or repeated failure, log clearly so monitoring tools can detect the issue
+- **Health check (future):** Periodically verify strategies remain enabled (NT8 can disable strategies on errors)
+
+## Technical Details
+
+- **Language:** C# / .NET
+- **UI Automation:** UIA3 (via existing project's framework/library)
+- **NT8 version:** NinjaTrader 8 (WPF-based desktop application)
+- **Target:** Windows, running on unattended server/VPS
+
+## Constraints & Risks
+
+- **Unsupported by NinjaTrader:** This workaround is explicitly not supported. NT8 intentionally requires manual strategy enabling.
+- **UI changes:** NT8 updates may change UI element names, automation IDs, or visual tree structure, requiring automation selector updates.
+- **Timing sensitivity:** If strategies are enabled before data is fully loaded, they may start in an incorrect state. The connection verification + buffer delay mitigates this.
+- **Single connection:** Current design assumes a single data/broker connection. Would need adjustment for multiple connections.
+
+## Open Items
+
+- Exact UIA3 element selectors for Control Center, Strategies tab, and strategy grid need to be mapped by inspecting the live UI tree (using Inspect.exe or FlaUI's tooling)
+- Integration point with existing UIA3 app code to be determined when project is shared

--- a/docs/plans/2026-03-04-nt8-strategy-autostart-implementation.md
+++ b/docs/plans/2026-03-04-nt8-strategy-autostart-implementation.md
@@ -1,0 +1,268 @@
+# NT8 Strategy Auto-Start Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the existing NT8 login automater to find the Control Center after login, verify the data connection, and enable all strategies in the Strategies tab.
+
+**Architecture:** After login and live/sim selection (existing code), poll for the Control Center window by title. Once found, verify connection status, navigate to the Strategies tab, and toggle the Enabled checkbox on each strategy row. All new code stays in `Program.cs` as top-level statements, following the existing pattern.
+
+**Tech Stack:** C# / .NET 8.0-windows, FlaUI.UIA3 v5.0.0
+
+---
+
+### Task 1: Find the Control Center Window After Login
+
+**Files:**
+- Modify: `TreyThomasCodes.Nt8Automater/Program.cs:37-44` (append after existing code)
+
+After login + live/sim selection, the splash screen closes and the Control Center window appears as a new top-level window. We need to poll for it.
+
+**Step 1: Add Control Center discovery code**
+
+Append after the existing live/sim block (line 44) in `Program.cs`:
+
+```csharp
+// --- Phase 1: Find the Control Center window ---
+Console.WriteLine("Waiting for Control Center window...");
+var controlCenter = Retry.WhileNull(
+    () =>
+    {
+        var windows = app.GetAllTopLevelWindows(automation);
+        return windows.FirstOrDefault(w => w.Title.Contains("Control Center"));
+    },
+    TimeSpan.FromSeconds(120),
+    TimeSpan.FromSeconds(2)
+);
+var ccWindow = controlCenter.Result
+    ?? throw new InvalidOperationException("Control Center window did not appear within timeout.");
+Console.WriteLine($"Found Control Center: \"{ccWindow.Title}\"");
+```
+
+**Key details for implementer:**
+- `app.GetAllTopLevelWindows(automation)` returns all windows owned by the NT8 process
+- The Control Center window title typically contains "Control Center" — use `Contains` rather than exact match in case NT8 appends version info or account name
+- `Retry.WhileNull` polls every 2 seconds for up to 120 seconds — generous timeout for login + workspace loading
+- The splash window may still be closing during this period; `GetAllTopLevelWindows` handles that gracefully
+
+**Step 2: Build and verify it compiles**
+
+Run: `dotnet build TreyThomasCodes.Nt8Automater.sln`
+Expected: Build succeeded, 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add TreyThomasCodes.Nt8Automater/Program.cs
+git commit -m "feat: find Control Center window after login"
+```
+
+---
+
+### Task 2: Verify Data Connection Status
+
+**Files:**
+- Modify: `TreyThomasCodes.Nt8Automater/Program.cs` (append after Task 1 code)
+
+The Control Center shows connection status. We need to wait until the data connection is established before enabling strategies. The connection status appears in the Control Center — the exact UI element will need discovery via FlaUI's element inspection.
+
+**Important note:** The exact AutomationId or element name for the connection status is unknown and must be discovered at runtime on the target machine. We'll implement a flexible approach: first try known patterns, then fall back to a configurable time delay.
+
+**Step 1: Add connection verification with configurable delay**
+
+Append after the Control Center discovery code:
+
+```csharp
+// --- Phase 2: Wait for connection readiness ---
+var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 30;
+Console.WriteLine($"Waiting {delaySec}s for connections and charts to initialize...");
+Thread.Sleep(TimeSpan.FromSeconds(delaySec));
+Console.WriteLine("Connection delay complete.");
+```
+
+**Why a simple delay first:** The connection status UI element's AutomationId is unknown without inspecting the live NT8 process. A configurable delay (`NT8A_CONN_DELAY` env var, default 30s) is the reliable baseline. The user can later inspect the UI tree with FlaUI's tooling and add proper connection polling as an enhancement.
+
+**Step 2: Build and verify**
+
+Run: `dotnet build TreyThomasCodes.Nt8Automater.sln`
+Expected: Build succeeded, 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add TreyThomasCodes.Nt8Automater/Program.cs
+git commit -m "feat: add configurable connection delay before strategy enable"
+```
+
+---
+
+### Task 3: Navigate to the Strategies Tab and Enable All Strategies
+
+**Files:**
+- Modify: `TreyThomasCodes.Nt8Automater/Program.cs` (append after Task 2 code)
+
+The Strategies tab in the Control Center shows a data grid with an "Enabled" checkbox column. We need to:
+1. Click the "Strategies" tab
+2. Find all strategy rows in the grid
+3. For each row, find the Enabled checkbox and check it if unchecked
+
+**Step 1: Add strategy enabling code**
+
+Append after the connection delay code:
+
+```csharp
+// --- Phase 3: Navigate to Strategies tab and enable all strategies ---
+Console.WriteLine("Looking for Strategies tab...");
+var strategiesTab = Retry.WhileNull(
+    () => ccWindow.FindFirstDescendant(cf => cf.ByName("Strategies"))
+        ?? ccWindow.FindFirstDescendant(cf => cf.ByAutomationId("Strategies")),
+    TimeSpan.FromSeconds(30),
+    TimeSpan.FromSeconds(2)
+);
+var tabElement = strategiesTab.Result
+    ?? throw new InvalidOperationException("Could not find Strategies tab in Control Center.");
+
+// Click the Strategies tab to make sure it's selected
+tabElement.Click();
+Console.WriteLine("Strategies tab selected.");
+Thread.Sleep(TimeSpan.FromSeconds(2)); // Brief pause for tab content to render
+
+// Find the strategies data grid
+var grid = Retry.WhileNull(
+    () => ccWindow.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.DataGrid))
+        ?? ccWindow.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.Table)),
+    TimeSpan.FromSeconds(15),
+    TimeSpan.FromSeconds(2)
+);
+var strategiesGrid = grid.Result
+    ?? throw new InvalidOperationException("Could not find strategies grid.");
+
+// Find all rows and enable each strategy
+var rows = strategiesGrid.FindAllDescendants(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.DataItem));
+if (rows.Length == 0)
+    rows = strategiesGrid.FindAllDescendants(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.Custom));
+
+Console.WriteLine($"Found {rows.Length} strategy row(s).");
+
+var enabled = 0;
+foreach (var row in rows)
+{
+    // Find the Enabled checkbox within this row
+    var checkbox = row.FindFirstDescendant(cf => cf.ByControlType(FlaUI.Core.Definitions.ControlType.CheckBox));
+    if (checkbox is null)
+    {
+        Console.WriteLine($"  Row: no checkbox found, skipping.");
+        continue;
+    }
+
+    var cb = checkbox.AsCheckBox();
+    var strategyName = row.Name ?? "unknown";
+    if (cb.IsChecked == true)
+    {
+        Console.WriteLine($"  {strategyName}: already enabled.");
+    }
+    else
+    {
+        cb.IsChecked = true;
+        enabled++;
+        Console.WriteLine($"  {strategyName}: enabled.");
+    }
+}
+
+Console.WriteLine($"Done. Enabled {enabled} strategy/strategies. {rows.Length - enabled} were already enabled or skipped.");
+```
+
+**Key details for implementer:**
+- Tab discovery: tries both `ByName("Strategies")` and `ByAutomationId("Strategies")` since we don't know the exact identifier
+- Grid discovery: tries both `DataGrid` and `Table` control types — WPF apps can use either
+- Row discovery: tries `DataItem` then `Custom` — NT8 may use custom row types
+- Checkbox: each row should contain one CheckBox for the "Enabled" column
+- `cb.IsChecked = true` programmatically checks the box via UIA3's Toggle pattern
+- `row.Name` may contain the strategy name for logging
+
+**Step 2: Build and verify**
+
+Run: `dotnet build TreyThomasCodes.Nt8Automater.sln`
+Expected: Build succeeded, 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add TreyThomasCodes.Nt8Automater/Program.cs
+git commit -m "feat: enable all strategies in Control Center Strategies tab"
+```
+
+---
+
+### Task 4: Update CLAUDE.md with New Environment Variables
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Update the Configuration section**
+
+In `CLAUDE.md`, add the new env var to the Configuration section and update the project description:
+
+Update the **Project Overview** line to:
+```
+A Windows console app that automates NinjaTrader 8 login and strategy enabling using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches or attaches to NinjaTrader, fills in credentials, clicks login, selects live or simulation mode, then finds the Control Center and enables all strategies.
+```
+
+Add to the **Configuration** list:
+```
+- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `30`.
+```
+
+Update the **Key Dependency** version to match csproj:
+```
+**FlaUI.UIA3 v5.0.0**
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with strategy auto-start details"
+```
+
+---
+
+### Task 5: Manual Testing on Target Machine
+
+This task cannot be automated — it requires running against the actual NinjaTrader 8 installation.
+
+**Step 1: Inspect the UI tree**
+
+Before running, use FlaUI Inspect (or Windows Inspect.exe from Windows SDK) on a running NT8 instance to verify:
+- The Control Center window title contains "Control Center"
+- The Strategies tab element name or AutomationId
+- The grid control type (DataGrid vs Table)
+- The row control type (DataItem vs Custom)
+- The Enabled checkbox is a standard CheckBox control type
+
+**Step 2: Run with verbose output**
+
+```bash
+NT8A_USER=your_user NT8A_PASS=your_pass NT8A_LIVE=FALSE NT8A_CONN_DELAY=30 dotnet run --project TreyThomasCodes.Nt8Automater
+```
+
+Watch the console output for each phase. If any element isn't found, inspect the UI tree and adjust the selectors in `Program.cs`.
+
+**Step 3: Tune the connection delay**
+
+If strategies are enabled too early (before data loads), increase `NT8A_CONN_DELAY`. If 30s is too long, decrease it.
+
+**Step 4: Verify strategies are running**
+
+Check the NT8 Strategies tab — all strategies should show green (enabled/running).
+
+---
+
+## Known Limitations & Future Improvements
+
+1. **Element selectors are best-guess** — the exact AutomationIds, control types, and element names for the Control Center Strategies tab are unknown without inspecting a live NT8 instance. Task 5 is critical for validating and adjusting selectors.
+
+2. **Connection delay vs. connection polling** — the initial implementation uses a fixed delay. A future improvement could poll the actual connection status indicator once its AutomationId is discovered.
+
+3. **Right-click context menu** — if the checkbox approach doesn't work, the NT8 Strategies tab supports right-clicking a strategy and selecting "Enable" from the context menu. This is an alternative interaction pattern if needed.
+
+4. **Strategy-specific enabling** — current design enables ALL strategies. A future `NT8A_STRATEGIES` env var could accept a comma-separated list of strategy names to enable selectively.

--- a/docs/plans/2026-03-04-nt8-strategy-autostart-implementation.md
+++ b/docs/plans/2026-03-04-nt8-strategy-autostart-implementation.md
@@ -73,13 +73,13 @@ Append after the Control Center discovery code:
 
 ```csharp
 // --- Phase 2: Wait for connection readiness ---
-var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 30;
+var delaySec = int.TryParse(Environment.GetEnvironmentVariable("NT8A_CONN_DELAY"), out var d) ? d : 10;
 Console.WriteLine($"Waiting {delaySec}s for connections and charts to initialize...");
 Thread.Sleep(TimeSpan.FromSeconds(delaySec));
 Console.WriteLine("Connection delay complete.");
 ```
 
-**Why a simple delay first:** The connection status UI element's AutomationId is unknown without inspecting the live NT8 process. A configurable delay (`NT8A_CONN_DELAY` env var, default 30s) is the reliable baseline. The user can later inspect the UI tree with FlaUI's tooling and add proper connection polling as an enhancement.
+**Why a simple delay first:** The connection status UI element's AutomationId is unknown without inspecting the live NT8 process. A configurable delay (`NT8A_CONN_DELAY` env var, default 10s) is the reliable baseline. The user can later inspect the UI tree with FlaUI's tooling and add proper connection polling as an enhancement.
 
 **Step 2: Build and verify**
 
@@ -162,9 +162,20 @@ foreach (var row in rows)
     }
     else
     {
-        cb.IsChecked = true;
-        enabled++;
-        Console.WriteLine($"  {strategyName}: enabled.");
+        cb.Click();
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (cb.IsChecked != true && DateTime.UtcNow < deadline)
+            Thread.Sleep(100);
+
+        if (cb.IsChecked == true)
+        {
+            enabled++;
+            Console.WriteLine($"  {strategyName}: enabled.");
+        }
+        else
+        {
+            Console.WriteLine($"  WARNING: {strategyName} checkbox did not toggle to enabled.");
+        }
     }
 }
 
@@ -176,7 +187,7 @@ Console.WriteLine($"Done. Enabled {enabled} strategy/strategies. {rows.Length - 
 - Grid discovery: tries both `DataGrid` and `Table` control types — WPF apps can use either
 - Row discovery: tries `DataItem` then `Custom` — NT8 may use custom row types
 - Checkbox: each row should contain one CheckBox for the "Enabled" column
-- `cb.IsChecked = true` programmatically checks the box via UIA3's Toggle pattern
+- `cb.Click()` toggles the checkbox via a UI click, followed by a short poll loop to verify the state changed
 - `row.Name` may contain the strategy name for logging
 
 **Step 2: Build and verify**
@@ -204,12 +215,12 @@ In `CLAUDE.md`, add the new env var to the Configuration section and update the 
 
 Update the **Project Overview** line to:
 ```
-A Windows console app that automates NinjaTrader 8 login and strategy enabling using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches or attaches to NinjaTrader, fills in credentials, clicks login, selects live or simulation mode, then finds the Control Center and enables all strategies.
+A Windows console app that automates NinjaTrader 8 login and strategy enabling using UI Automation (FlaUI). Single-file C# app with top-level statements. Launches NinjaTrader (aborts if already running), fills in credentials, clicks login, selects live or simulation mode, then finds the Control Center and enables all strategies.
 ```
 
 Add to the **Configuration** list:
 ```
-- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `30`.
+- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections after login before enabling strategies. Defaults to `10`.
 ```
 
 Update the **Key Dependency** version to match csproj:
@@ -242,14 +253,14 @@ Before running, use FlaUI Inspect (or Windows Inspect.exe from Windows SDK) on a
 **Step 2: Run with verbose output**
 
 ```bash
-NT8A_USER=your_user NT8A_PASS=your_pass NT8A_LIVE=FALSE NT8A_CONN_DELAY=30 dotnet run --project TreyThomasCodes.Nt8Automater
+NT8A_USER=your_user NT8A_PASS=your_pass NT8A_LIVE=FALSE NT8A_CONN_DELAY=10 dotnet run --project TreyThomasCodes.Nt8Automater
 ```
 
 Watch the console output for each phase. If any element isn't found, inspect the UI tree and adjust the selectors in `Program.cs`.
 
 **Step 3: Tune the connection delay**
 
-If strategies are enabled too early (before data loads), increase `NT8A_CONN_DELAY`. If 30s is too long, decrease it.
+If strategies are enabled too early (before data loads), increase `NT8A_CONN_DELAY`. If 10s is too long, decrease it.
 
 **Step 4: Verify strategies are running**
 


### PR DESCRIPTION
## Summary

- Finds the Control Center window after login completes (polls up to 120s)
- Waits a configurable delay for data connections to establish (`NT8A_CONN_DELAY`, default 30s)
- Navigates to the Strategies tab and enables all strategies by clicking each Enabled checkbox
- Verifies each checkbox toggled successfully, warns if not

## New environment variable

- `NT8A_CONN_DELAY` - (optional) seconds to wait for connections before enabling strategies. Defaults to `30`.

## Notes

- UI element selectors (tab name, grid type, checkbox) are best-guess from NT8 documentation — may need adjustment after inspecting the live UI tree with FlaUI Inspect or Windows Inspect.exe
- This is an unsupported workaround; NT8 intentionally requires manual strategy enabling

## Test plan

- [x] Inspect NT8 UI tree to verify element selectors match
- [x] Run with `NT8A_CONN_DELAY=30` and verify strategies enable correctly
- [x] Tune delay value if strategies enable before data is ready
- [x] Verify console output logs each phase and strategy status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically enables all NinjaTrader 8 strategies after login.
  * Added NT8A_CONN_DELAY to tune wait time before enabling strategies (default 10s).

* **Documentation**
  * Updated project name, README, and added design/implementation docs describing the auto-start flow and configuration.

* **Chores**
  * Upgraded UI automation dependency to a newer compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->